### PR TITLE
Create .selenium/perl-client automatically and don't hard-code .selen…

### DIFF
--- a/lib/Selenium/Client.pm
+++ b/lib/Selenium/Client.pm
@@ -14,6 +14,7 @@ use Carp qw{confess};
 use File::Path qw{make_path};
 use File::HomeDir();
 use File::Slurper();
+use File::Spec();
 use Sub::Install();
 use Net::EmptyPort();
 use Capture::Tiny qw{capture_merged};
@@ -136,8 +137,11 @@ sub new($class,%options) {
     $options{auto_close} //= 1;
     $options{browser}    //= '';
 
+    #create client_dir and log-dir
+    my $dir = File::Spec->catdir( $options{client_dir},"perl-client" );
+    make_path($dir);
     #Grab the spec
-    $options{spec}       = Selenium::Specification::read($options{version},$options{nofetch});
+    $options{spec}= Selenium::Specification::read($options{client_dir},$options{version},$options{nofetch});
 
     my $self = bless(\%options, $class);
     $self->{sessions} = [];

--- a/lib/Selenium/Specification.pm
+++ b/lib/Selenium/Specification.pm
@@ -39,7 +39,6 @@ our %spec_urls = (
 our $browser = HTTP::Tiny->new();
 my %state;
 my $parse = [];
-my $dir = File::Spec->catdir( File::HomeDir::my_home(),".selenium","specs" );
 our $method = {};
 
 =head1 SUBROUTINES
@@ -50,9 +49,10 @@ Reads the copy of the provided spec type, and fetches it if a cached version is 
 
 =cut
 
-sub read($type='stable', $nofetch=1) {
+sub read($client_dir, $type='stable', $nofetch=1) {
+    my $dir = File::Spec->catdir( $client_dir,"specs" );
     my $file =  File::Spec->catfile( "$dir","$type.json");
-    fetch( once => $nofetch );
+    fetch( once => $nofetch, dir => $dir );
     die "could not write $file: $@" unless -f $file;
     my $buf = File::Slurper::read_text($file);
     my $array = JSON::MaybeXS::decode_json($buf);
@@ -69,7 +69,7 @@ Builds a spec hash based upon the WC3 specification documents, and writes it to 
 
 #TODO needs to grab args and argtypes still
 sub fetch (%options) {
-    $dir = $options{dir} if $options{dir};
+    my $dir = $options{dir};
 
     my $rc = 0;
     foreach my $spec ( sort keys(%spec_urls) ) {


### PR DESCRIPTION
…ium in Selenium::Specification

I had to create .selenium/perl-client manually and then noticed that the path was hard-coded
in Selenium::Specification.
No idea whether this fits your plans for Selenium::Specification, though.